### PR TITLE
fix possible infinite loop while parsing for broken replays

### DIFF
--- a/src/Unreal.Core/ReplayReader.cs
+++ b/src/Unreal.Core/ReplayReader.cs
@@ -317,6 +317,13 @@ public abstract class ReplayReader<T> where T : Replay, new()
             var chunkSize = archive.ReadInt32();
             var offset = archive.Position;
 
+            if (chunkSize <= 0 || (long) chunkSize + offset > int.MaxValue)
+            {
+                _logger?.LogError("Invalid chunk size ({chunkSize} for chunk {chunkType}) at offset {offset}. Stopping the parsing...", chunkSize, chunkType, archive.Position);
+                archive.SetError();
+                return;
+            }
+
             if (chunkType == ReplayChunkType.ReplayData && _parseMode > ParseMode.EventsOnly)
             {
                 ReadReplayData(archive, chunkSize);


### PR DESCRIPTION
When a broken replay file is passed as input, there is a possibility of the endless loop while reading chunks

I tried to make a quick fix there. Please adjust this as required according to the repository/project standards.