### PR TITLE
fix: prevent infinite loop when a bunch overflows its packet (#74)

### DIFF
--- a/src/Unreal.Core/ReplayReader.cs
+++ b/src/Unreal.Core/ReplayReader.cs
@@ -2091,12 +2091,6 @@ public abstract class ReplayReader<T> where T : Replay, new()
                 bunch.Archive = bitReader;
             }
 
-            // If the bunch claims to be larger than the data remaining in the packet, the stream is
-            // malformed/misaligned. Both ReadBits (partial) and SetTempEnd (non-partial) flag this by
-            // setting IsError without advancing the reader. Continuing would corrupt the temp-end
-            // bookkeeping and spin this loop forever, so bail out of the packet like the engine does
-            // in UNetConnection::ReceivedPacket when Reader.IsError() is true after FInBunch::SetData
-            // (Engine/Source/Runtime/Engine/Private/NetConnection.cpp, same source as the links above).
             if (bitReader.IsError)
             {
                 _logger?.LogWarning("ReceivedPacket: bunch ({bunchDataBits} bits) overflows packet {packetIndex}, aborting packet.", bunchDataBits, packetIndex);

--- a/src/Unreal.Core/ReplayReader.cs
+++ b/src/Unreal.Core/ReplayReader.cs
@@ -2091,6 +2091,18 @@ public abstract class ReplayReader<T> where T : Replay, new()
                 bunch.Archive = bitReader;
             }
 
+            // If the bunch claims to be larger than the data remaining in the packet, the stream is
+            // malformed/misaligned. Both ReadBits (partial) and SetTempEnd (non-partial) flag this by
+            // setting IsError without advancing the reader. Continuing would corrupt the temp-end
+            // bookkeeping and spin this loop forever, so bail out of the packet like the engine does
+            // in UNetConnection::ReceivedPacket when Reader.IsError() is true after FInBunch::SetData
+            // (Engine/Source/Runtime/Engine/Private/NetConnection.cpp, same source as the links above).
+            if (bitReader.IsError)
+            {
+                _logger?.LogWarning("ReceivedPacket: bunch ({bunchDataBits} bits) overflows packet {packetIndex}, aborting packet.", bunchDataBits, packetIndex);
+                break;
+            }
+
             bunchIndex++;
 
             if (bunch.bHasPackageMapExports)


### PR DESCRIPTION
## Problem

Fixes #74. On some replays from newer Fortnite builds (e.g. `++Fortnite+Release-41.00`), `ReadReplay` hangs indefinitely in every mode that reads net data (`Minimal`/`Normal`/`Full`) while `EventsOnly` succeeds in ~0.1s.

## Root cause

Captured via a process dump of the hung run: the loop in `ReceivedPacket` (`while (!bitReader.AtEnd())`) is stuck on a single packet — `Position` frozen at ~236 of `LastBit=1603` while `bunchIndex` climbs by ~150M every 15s.

A misalignment in the packet bit stream yields a **non-partial** bunch that reports `bunchDataBits` larger than the bits remaining in the packet (observed `8723` with only ~1339 left). In that case:

- non-partial: `SetTempEnd(bunchDataBits)` takes its overflow branch — sets `IsError` and returns **without** pushing the temp-end,
- partial: `ReadBits(bunchDataBits)` sets `IsError` and returns `[]`,

both leaving the reader un-advanced. The loop then keeps reprocessing the same position forever, so the parse never terminates. The engine network version (44) is unchanged from working replays, which is why older 5.8.0 replays are unaffected — the trigger is a content/layout change in the new build.

## Fix

After sizing the bunch, if the reader is in an error state, log a warning and `break` out of the packet — matching `UNetConnection::ReceivedPacket`, which stops once the reader is in error after `FInBunch::SetData`. `FillBuffer` resets the reader for the next packet, so bailing is clean. Only the single malformed packet is skipped.

## Verification

- All affected replays now parse in ~0.6–1.3s (were hanging indefinitely).
- The affected file recovers full data — 120 players, 118 eliminations, 135 killfeed entries — with the packet-abort firing only **once** in the entire file.
- Older replays parse identically (no regression).
- Full test suite passes: 261 tests, 0 failures (2 pre-existing skips) across all test projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)